### PR TITLE
BUG 修复五合一

### DIFF
--- a/src/dotnetCampus.Configurations/IO/FileWatcher.cs
+++ b/src/dotnetCampus.Configurations/IO/FileWatcher.cs
@@ -90,7 +90,11 @@ namespace dotnetCampus.IO
                 _watcher = new FileSystemWatcher(directory, file)
                 {
                     EnableRaisingEvents = true,
-                    NotifyFilter = NotifyFilters.LastWrite,
+                    NotifyFilter =
+                        // 文件被修改
+                        NotifyFilters.LastWrite
+                        // 文件被删除
+                        | NotifyFilters.FileName,
                 };
                 var weakEvent = new FileSystemWatcherWeakEventRelay(_watcher);
                 weakEvent.Changed += FinalFile_Changed;


### PR DESCRIPTION
* 修复删除配置文件不会立即读取到新值的问题
* 修复单纯读文件时，文件改变也会被视为自己写的
* 解决删除的文件被用户手动撤回时，字典误以为自己比文件更新的问题（我们认为修改优先级高于程序）
* 如遇冲突，则重试
* 删除的文件再撤回，会无法读取到