### PR TITLE
判断文件夹存在时，判断目录联接

### DIFF
--- a/src/dotnetCampus.Configurations/IO/FileWatcher.cs
+++ b/src/dotnetCampus.Configurations/IO/FileWatcher.cs
@@ -192,7 +192,7 @@ namespace dotnetCampus.IO
                 }
 
                 // 检查文件夹是否存在，只要文件夹存在，那么就可以返回。
-                if (Directory.Exists(directory))
+                if (JunctionPoint.CheckDirectoryExistsWithJunctionPoint(directory))
                 {
                     return new FolderPair(directory, file);
                 }

--- a/src/dotnetCampus.Configurations/IO/ReparsePoint.cs
+++ b/src/dotnetCampus.Configurations/IO/ReparsePoint.cs
@@ -1,0 +1,307 @@
+﻿// File: RollThroughLibrary/CreateMaps/JunctionPoint.cs
+// User: Adrian Hum/
+// 
+// Created:  2017-11-19 2:46 PM
+// Modified: 2017-11-19 6:10 PM
+
+#nullable disable
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Microsoft.Win32.SafeHandles;
+
+namespace dotnetCampus.Configurations.IO
+{
+    /// <summary>
+    /// Provides access to NTFS junction points in .Net.
+    /// </summary>
+    public static class JunctionPoint
+    {
+        /// <summary>
+        /// The file or directory is not a reparse point.
+        /// </summary>
+        private const int ERROR_NOT_A_REPARSE_POINT = 4390;
+
+        /// <summary>
+        /// The reparse point attribute cannot be set because it conflicts with an existing attribute.
+        /// </summary>
+        private const int ERROR_REPARSE_ATTRIBUTE_CONFLICT = 4391;
+
+        /// <summary>
+        /// The data present in the reparse point buffer is invalid.
+        /// </summary>
+        private const int ERROR_INVALID_REPARSE_DATA = 4392;
+
+        /// <summary>
+        /// The tag present in the reparse point buffer is invalid.
+        /// </summary>
+        private const int ERROR_REPARSE_TAG_INVALID = 4393;
+
+        /// <summary>
+        /// There is a mismatch between the tag specified in the request and the tag present in the reparse point.
+        /// </summary>
+        private const int ERROR_REPARSE_TAG_MISMATCH = 4394;
+
+        /// <summary>
+        /// Command to set the reparse point data block.
+        /// </summary>
+        private const int FSCTL_SET_REPARSE_POINT = 0x000900A4;
+
+        /// <summary>
+        /// Command to get the reparse point data block.
+        /// </summary>
+        private const int FSCTL_GET_REPARSE_POINT = 0x000900A8;
+
+        /// <summary>
+        /// Command to delete the reparse point data base.
+        /// </summary>
+        private const int FSCTL_DELETE_REPARSE_POINT = 0x000900AC;
+
+        /// <summary>
+        /// Reparse point tag used to identify mount points and junction points.
+        /// </summary>
+        private const uint IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003;
+
+        /// <summary>
+        /// This prefix indicates to NTFS that the path is to be treated as a non-interpreted
+        /// path in the virtual file system.
+        /// </summary>
+        private const string NonInterpretedPathPrefix = @"\??\";
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern bool DeviceIoControl(IntPtr hDevice, uint dwIoControlCode,
+            IntPtr InBuffer, int nInBufferSize,
+            IntPtr OutBuffer, int nOutBufferSize,
+            out int pBytesReturned, IntPtr lpOverlapped);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr CreateFile(
+            string lpFileName,
+            EFileAccess dwDesiredAccess,
+            EFileShare dwShareMode,
+            IntPtr lpSecurityAttributes,
+            ECreationDisposition dwCreationDisposition,
+            EFileAttributes dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        /// <summary>
+        /// Determines whether the specified path exists and refers to a junction point.
+        /// </summary>
+        /// <param name="path">The junction point path</param>
+        /// <returns>True if the specified path represents a junction point</returns>
+        /// <exception cref="IOException">
+        /// Thrown if the specified path is invalid
+        /// or some other error occurs
+        /// </exception>
+        public static bool Exists(string path)
+        {
+            if (!Directory.Exists(path))
+                return false;
+
+            using (var handle = OpenReparsePoint(path, EFileAccess.GenericRead))
+            {
+                var target = InternalGetTarget(handle);
+                return target != null && Directory.Exists(target);
+            }
+        }
+
+        /// <summary>
+        /// 检查文件夹是否存在。如果传入的路径是一个目录联接，则判断目录联接的目标是否存在。
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static bool CheckDirectoryExistsWithJunctionPoint(string path)
+        {
+            var nativeExists = Directory.Exists(path);
+            if (!nativeExists)
+            {
+                // 此条件表示：目录不存在，目录联接也不存在。
+                return false;
+            }
+
+            // 尝试打开目录联接。
+            using (var handle = OpenReparsePoint(path, EFileAccess.GenericRead))
+            {
+                var target = InternalGetTarget(handle);
+                if (target is null)
+                {
+                    // 这不是一个目录联接，判断原始路径。
+                    return nativeExists;
+                }
+                else
+                {
+                    // 这是一个目录联接，判断目标路径。
+                    return Directory.Exists(target);
+                }
+            }
+
+        }
+
+        private static string InternalGetTarget(SafeFileHandle handle)
+        {
+            var outBufferSize = Marshal.SizeOf(typeof(REPARSE_DATA_BUFFER));
+            var outBuffer = Marshal.AllocHGlobal(outBufferSize);
+
+            try
+            {
+                int bytesReturned;
+                var result = DeviceIoControl(handle.DangerousGetHandle(), FSCTL_GET_REPARSE_POINT,
+                    IntPtr.Zero, 0, outBuffer, outBufferSize, out bytesReturned, IntPtr.Zero);
+
+                if (!result)
+                {
+                    var error = Marshal.GetLastWin32Error();
+                    if (error == ERROR_NOT_A_REPARSE_POINT)
+                        return null;
+
+                    ThrowLastWin32Error("Unable to get information about junction point.");
+                }
+
+                var reparseDataBuffer = (REPARSE_DATA_BUFFER)
+                    Marshal.PtrToStructure(outBuffer, typeof(REPARSE_DATA_BUFFER));
+
+                if (reparseDataBuffer.ReparseTag != IO_REPARSE_TAG_MOUNT_POINT)
+                    return null;
+
+                var targetDir = Encoding.Unicode.GetString(reparseDataBuffer.PathBuffer,
+                    reparseDataBuffer.SubstituteNameOffset, reparseDataBuffer.SubstituteNameLength);
+
+                if (targetDir.StartsWith(NonInterpretedPathPrefix))
+                    targetDir = targetDir.Substring(NonInterpretedPathPrefix.Length);
+
+                return targetDir;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(outBuffer);
+            }
+        }
+
+        private static SafeFileHandle OpenReparsePoint(string reparsePoint, EFileAccess accessMode)
+        {
+            var reparsePointHandle = new SafeFileHandle(CreateFile(reparsePoint, accessMode,
+                EFileShare.Read | EFileShare.Write | EFileShare.Delete,
+                IntPtr.Zero, ECreationDisposition.OpenExisting,
+                EFileAttributes.BackupSemantics | EFileAttributes.OpenReparsePoint, IntPtr.Zero), true);
+
+            if (Marshal.GetLastWin32Error() != 0)
+                ThrowLastWin32Error("Unable to open reparse point.");
+
+            return reparsePointHandle;
+        }
+
+        private static void ThrowLastWin32Error(string message)
+        {
+            throw new IOException(message, Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()));
+        }
+
+        [Flags]
+        private enum EFileAccess : uint
+        {
+            GenericRead = 0x80000000,
+            GenericWrite = 0x40000000,
+            GenericExecute = 0x20000000,
+            GenericAll = 0x10000000
+        }
+
+        [Flags]
+        private enum EFileShare : uint
+        {
+            None = 0x00000000,
+            Read = 0x00000001,
+            Write = 0x00000002,
+            Delete = 0x00000004
+        }
+
+        private enum ECreationDisposition : uint
+        {
+            New = 1,
+            CreateAlways = 2,
+            OpenExisting = 3,
+            OpenAlways = 4,
+            TruncateExisting = 5
+        }
+
+        [Flags]
+        private enum EFileAttributes : uint
+        {
+            Readonly = 0x00000001,
+            Hidden = 0x00000002,
+            System = 0x00000004,
+            Directory = 0x00000010,
+            Archive = 0x00000020,
+            Device = 0x00000040,
+            Normal = 0x00000080,
+            Temporary = 0x00000100,
+            SparseFile = 0x00000200,
+            ReparsePoint = 0x00000400,
+            Compressed = 0x00000800,
+            Offline = 0x00001000,
+            NotContentIndexed = 0x00002000,
+            Encrypted = 0x00004000,
+            Write_Through = 0x80000000,
+            Overlapped = 0x40000000,
+            NoBuffering = 0x20000000,
+            RandomAccess = 0x10000000,
+            SequentialScan = 0x08000000,
+            DeleteOnClose = 0x04000000,
+            BackupSemantics = 0x02000000,
+            PosixSemantics = 0x01000000,
+            OpenReparsePoint = 0x00200000,
+            OpenNoRecall = 0x00100000,
+            FirstPipeInstance = 0x00080000
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct REPARSE_DATA_BUFFER
+        {
+            /// <summary>
+            /// Reparse point tag. Must be a Microsoft reparse point tag.
+            /// </summary>
+            public uint ReparseTag;
+
+            /// <summary>
+            /// Size, in bytes, of the data after the Reserved member. This can be calculated by:
+            /// (4 * sizeof(ushort)) + SubstituteNameLength + PrintNameLength +
+            /// (namesAreNullTerminated ? 2 * sizeof(char) : 0);
+            /// </summary>
+            public ushort ReparseDataLength;
+
+            /// <summary>
+            /// Reserved; do not use.
+            /// </summary>
+            public ushort Reserved;
+
+            /// <summary>
+            /// Offset, in bytes, of the substitute name string in the PathBuffer array.
+            /// </summary>
+            public ushort SubstituteNameOffset;
+
+            /// <summary>
+            /// Length, in bytes, of the substitute name string. If this string is null-terminated,
+            /// SubstituteNameLength does not include space for the null character.
+            /// </summary>
+            public ushort SubstituteNameLength;
+
+            /// <summary>
+            /// Offset, in bytes, of the print name string in the PathBuffer array.
+            /// </summary>
+            public ushort PrintNameOffset;
+
+            /// <summary>
+            /// Length, in bytes, of the print name string. If this string is null-terminated,
+            /// PrintNameLength does not include space for the null character.
+            /// </summary>
+            public ushort PrintNameLength;
+
+            /// <summary>
+            /// A buffer containing the unicode-encoded path string. The path string contains
+            /// the substitute name string and print name string.
+            /// </summary>
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x3FF0)] public byte[] PathBuffer;
+        }
+    }
+}

--- a/tests/dotnetCampus.Configurations.Tests/FileWatcherTests.cs
+++ b/tests/dotnetCampus.Configurations.Tests/FileWatcherTests.cs
@@ -1,0 +1,31 @@
+﻿using dotnetCampus.IO;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using MSTest.Extensions.Contracts;
+
+using Walterlv.IO.PackageManagement;
+
+namespace dotnetCampus.Configurations.Tests
+{
+    [TestClass]
+    public class FileWatcherTests
+    {
+        /// <summary>
+        /// 当遇到目录联接文件夹时。
+        /// </summary>
+        [ContractTestCase]
+        public void 目录联接()
+        {
+            "监视一个目标已不存在的目录联接，不会堆栈溢出。".Test(async () =>
+            {
+                PackageDirectory.Create("1.0.0");
+                PackageDirectory.Link("current", "1.0.0", true);
+                PackageDirectory.Delete("1.0.0");
+
+                var watcher = new FileWatcher(@"current\a.txt");
+                await watcher.WatchAsync().ConfigureAwait(false);
+            });
+        }
+    }
+}

--- a/tests/dotnetCampus.Configurations.Tests/dotnetCampus.Configurations.Tests.csproj
+++ b/tests/dotnetCampus.Configurations.Tests/dotnetCampus.Configurations.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="MSTestEnhancer" Version="2.0.1" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Walterlv.IO.PackageManagement" Version="5.11.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
如果目录联接存在但其目标不存在，那么 `Directory.Exists` 判断时会为 true，使用 `FileSystemWatcher` 时却出现 `FileNotFoundException`。