### PR TITLE
（提升清单型配置的性能）允许不监听文件改变地读取配置

### DIFF
--- a/src/dotnetCampus.Configurations/Core/ConfigurationFactory.cs
+++ b/src/dotnetCampus.Configurations/Core/ConfigurationFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -13,8 +14,7 @@ namespace dotnetCampus.Configurations.Core
         /// <summary>
         /// 管理不同文件的 <see cref="IAppConfigurator"/> 的实例。
         /// </summary>
-        private static readonly ConcurrentDictionary<string, WeakReference<FileConfigurationRepo>> Configurations
-            = new ConcurrentDictionary<string, WeakReference<FileConfigurationRepo>>();
+        private static readonly ConcurrentDictionary<RepoKey, WeakReference<FileConfigurationRepo>> Configurations = new();
 
         /// <summary>
         /// 从文件创建默认的配置管理仓库，你将可以使用类似字典的方式管理线程和进程安全的应用程序配置。
@@ -23,7 +23,17 @@ namespace dotnetCampus.Configurations.Core
         /// </summary>
         /// <param name="fileName">来自于本地文件系统的文件名/路径。文件或文件所在的文件夹不需要提前存在。</param>
         /// <returns>一个用于管理指定文件的配置仓库。</returns>
-        public static FileConfigurationRepo FromFile(string fileName)
+        public static FileConfigurationRepo FromFile(string fileName) => FromFile(fileName, RepoSyncingBehavior.Sync);
+
+        /// <summary>
+        /// 从文件创建默认的配置管理仓库，你将可以使用类似字典的方式管理线程和进程安全的应用程序配置。
+        /// 对于同一个文件，此方法会获取到相同的 <see cref="FileConfigurationRepo"/> 的实例。
+        /// <para>此方法是线程安全的。</para>
+        /// </summary>
+        /// <param name="fileName">来自于本地文件系统的文件名/路径。文件或文件所在的文件夹不需要提前存在。</param>
+        /// <param name="syncingBehavior">指定应如何读取数据。是实时监听文件变更，还是只读一次，后续不再监听变更。后者性能更好。</param>
+        /// <returns>一个用于管理指定文件的配置仓库。</returns>
+        public static FileConfigurationRepo FromFile(string fileName, RepoSyncingBehavior syncingBehavior)
         {
             if (fileName == null)
             {
@@ -36,7 +46,7 @@ namespace dotnetCampus.Configurations.Core
             }
 
             var path = Path.GetFullPath(fileName);
-            var reference = Configurations.GetOrAdd(path, CreateConfigurationReference);
+            var reference = Configurations.GetOrAdd(new(path, syncingBehavior), CreateConfigurationReference);
 
             // 以下两个 if 一个 lock 是类似于单例模式的创建方式，既保证性能又保证只创建一次。
             if (!reference.TryGetTarget(out var config))
@@ -45,7 +55,7 @@ namespace dotnetCampus.Configurations.Core
                 {
                     if (!reference.TryGetTarget(out config))
                     {
-                        config = CreateConfiguration(path);
+                        config = CreateConfiguration(path, syncingBehavior);
                         reference.SetTarget(config);
                     }
                 }
@@ -58,21 +68,21 @@ namespace dotnetCampus.Configurations.Core
         /// 创建 <see cref="IAppConfigurator"/> 的弱引用实例。
         /// 为了保证线程安全，此方法仅能被 <see cref="Configurations"/> 访问。
         /// </summary>
-        /// <param name="path">已经过验证的完整文件路径。</param>
+        /// <param name="key">已经过验证的完整文件路径和外部数据同步方式。</param>
         /// <returns><see cref="IAppConfigurator"/> 的弱引用实例。</returns>
-        private static WeakReference<FileConfigurationRepo> CreateConfigurationReference(string path)
-            => new WeakReference<FileConfigurationRepo>(
-                CreateConfiguration(path));
+        private static WeakReference<FileConfigurationRepo> CreateConfigurationReference(RepoKey key)
+            => new(CreateConfiguration(key.FilePath, key.Syncing));
 
         /// <summary>
         /// 创建 <see cref="IAppConfigurator"/> 的新实例。
         /// 为了保证线程安全，此方法仅能被 <see cref="CreateConfigurationReference"/> 访问。
         /// </summary>
         /// <param name="path">已经过验证的完整文件路径。</param>
+        /// <param name="syncingBehavior">指定应如何读取数据。是实时监听文件变更，还是只读一次，后续不再监听变更。后者性能更好。</param>
         /// <returns><see cref="IAppConfigurator"/> 的新实例。</returns>
-        private static FileConfigurationRepo CreateConfiguration(string path)
+        private static FileConfigurationRepo CreateConfiguration(string path, RepoSyncingBehavior syncingBehavior)
 #pragma warning disable CS0618 // 类型或成员已过时
-            => new FileConfigurationRepo(path);
+            => new(path, syncingBehavior);
 #pragma warning restore CS0618 // 类型或成员已过时
 
         /// <summary>
@@ -91,6 +101,34 @@ namespace dotnetCampus.Configurations.Core
                 return repo.ReloadExternalChangesAsync();
             }
             return Task.FromResult<object?>(null);
+        }
+
+        private readonly struct RepoKey
+        {
+            public RepoKey(string filePath, RepoSyncingBehavior syncing)
+            {
+                FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+                Syncing = syncing;
+            }
+
+            public string FilePath { get; }
+
+            public RepoSyncingBehavior Syncing { get; }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is RepoKey key &&
+                       FilePath == key.FilePath &&
+                       Syncing == key.Syncing;
+            }
+
+            public override int GetHashCode()
+            {
+                var hashCode = -527002742;
+                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FilePath);
+                hashCode = hashCode * -1521134295 + Syncing.GetHashCode();
+                return hashCode;
+            }
         }
     }
 }

--- a/src/dotnetCampus.Configurations/Core/RepoSyncingBehavior.cs
+++ b/src/dotnetCampus.Configurations/Core/RepoSyncingBehavior.cs
@@ -1,0 +1,21 @@
+﻿namespace dotnetCampus.Configurations.Core
+{
+    /// <summary>
+    /// 表示配置仓库应如何与外部数据进行同步。
+    /// </summary>
+    public enum RepoSyncingBehavior
+    {
+        /// <summary>
+        /// 以高效的方式进行同步。
+        /// </summary>
+        /// <remarks>
+        /// 使用此方式会导致仓库监听外部文件的改变。
+        /// </remarks>
+        Sync,
+
+        /// <summary>
+        /// 不进行同步，首次读到值后将不再自动根据外部值更新数据，除非手动调用方法更新数据。
+        /// </summary>
+        Static,
+    }
+}


### PR DESCRIPTION
- 配置型：会被修改，因此总是需要读到新值。
- 清单型：无法被修改或修改无意义，因此首次读到值后即可正常使用，根本无需监听文件改变。