### PR TITLE
尝试修复打包

### DIFF
--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           3.1.x
@@ -27,7 +27,9 @@ jobs:
       run: dotnet tool install -g dotnetCampus.TagToVersion
 
     - name: Set tag to version  
-      run: dotnet-TagToVersion -t ${{ github.ref }}
+      run: |
+        dotnet tool list -g
+        dotnet TagToVersion -t ${{ github.ref }}
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -12,6 +12,13 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Install dotnet tool
+      run: dotnet tool install -g dotnetCampus.TagToVersion
+    - name: List dotnet tool
+      run: dotnet tool list -g
+    - name: Set tag to version  
+      run: cmd /c "dotnet TagToVersion"
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
@@ -22,13 +29,6 @@ jobs:
           7.0.x
           8.0.x
           9.0.x
-
-    - name: Install dotnet tool
-      run: dotnet tool install -g dotnetCampus.TagToVersion
-    - name: List dotnet tool
-      run: dotnet tool list -g
-    - name: Set tag to version  
-      run: cmd /c "dotnet TagToVersion"
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -25,7 +25,7 @@ jobs:
       run: dotnet tool install -g dotnetCampus.TagToVersion
 
     - name: Set tag to version  
-      run: dotnet TagToVersion -t ${{ github.ref }}
+      run: dotnet-TagToVersion -t ${{ github.ref }}
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Install dotnet tool
+      run: dotnet tool install -g dotnetCampus.TagToVersion
+
+    - name: Set tag to version  
+      run: cmd /c "dotnet TagToVersion -t ${{ github.ref }}"
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
@@ -22,13 +28,6 @@ jobs:
           7.0.x
           8.0.x
           9.0.x
-
-    - name: Install dotnet tool
-      run: dotnet tool install -g dotnetCampus.TagToVersion
-    - name: List dotnet tool
-      run: dotnet tool list -g
-    - name: Set tag to version  
-      run: cmd /c "dotnet TagToVersion -t ${{ github.ref }}"
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Add private GitHub registry to NuGet
       run: |
-        nuget sources add -name github -Source https://nuget.pkg.github.com/ORGANIZATION_NAME/index.json -Username ORGANIZATION_NAME -Password ${{ secrets.GITHUB_TOKEN }}
+        nuget sources add -name github -Source https://nuget.pkg.github.com/dotnet-campus/index.json -Username dotnet-campus -Password ${{ secrets.GITHUB_TOKEN }}
         
     - name: Push generated package to GitHub registry
       run: |

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -21,7 +21,6 @@ jobs:
           6.0.x
           7.0.x
           8.0.x
-          9.0.x
 
     - name: Install dotnet tool
       run: dotnet tool install -g dotnetCampus.TagToVersion

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -21,13 +21,14 @@ jobs:
           6.0.x
           7.0.x
           8.0.x
+          9.0.x
 
     - name: Install dotnet tool
       run: dotnet tool install -g dotnetCampus.TagToVersion
     - name: List dotnet tool
       run: dotnet tool list -g
     - name: Set tag to version  
-      run: dotnet TagToVersion -t ${{ github.ref }}
+      run: cmd /c "dotnet TagToVersion -t ${{ github.ref }}"
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -28,7 +28,7 @@ jobs:
     - name: List dotnet tool
       run: dotnet tool list -g
     - name: Set tag to version  
-      run: cmd /c "dotnet TagToVersion"
+      run: cmd /c "dotnet TagToVersion -t ${{ github.ref }}"
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -12,13 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Install dotnet tool
-      run: dotnet tool install -g dotnetCampus.TagToVersion
-    - name: List dotnet tool
-      run: dotnet tool list -g
-    - name: Set tag to version  
-      run: cmd /c "dotnet TagToVersion"
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
@@ -29,6 +22,13 @@ jobs:
           7.0.x
           8.0.x
           9.0.x
+
+    - name: Install dotnet tool
+      run: dotnet tool install -g dotnetCampus.TagToVersion
+    - name: List dotnet tool
+      run: dotnet tool list -g
+    - name: Set tag to version  
+      run: cmd /c "dotnet TagToVersion"
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -18,7 +18,9 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.0.100
+          6.0.x
+          7.0.x
+          8.0.x
           9.0.x
 
     - name: Install dotnet tool

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -28,7 +28,7 @@ jobs:
     - name: List dotnet tool
       run: dotnet tool list -g
     - name: Set tag to version  
-      run: cmd /c "dotnet TagToVersion -t ${{ github.ref }}"
+      run: cmd /c "dotnet TagToVersion"
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/.github/workflows/nuget publish.yml
+++ b/.github/workflows/nuget publish.yml
@@ -25,11 +25,10 @@ jobs:
 
     - name: Install dotnet tool
       run: dotnet tool install -g dotnetCampus.TagToVersion
-
+    - name: List dotnet tool
+      run: dotnet tool list -g
     - name: Set tag to version  
-      run: |
-        dotnet tool list -g
-        dotnet TagToVersion -t ${{ github.ref }}
+      run: dotnet TagToVersion -t ${{ github.ref }}
 
     - name: Build with dotnet
       run: dotnet build --configuration Release -v n

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.2.9</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
遇到很多 TagToVersion 无法运行的错误，只有退出错误 1 没有其他信息

```
Run cmd /c "dotnet TagToVersion -t refs/tags/1.9.0-alpha03"
  cmd /c "dotnet TagToVersion -t refs/tags/1.9.0-alpha03"
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    DOTNET_ROOT: C:\Program Files\dotnet
Error: Process completed with exit code 1.
```

![](https://github.com/user-attachments/assets/0b9e556d-2e59-438e-a229-40ac35c12a2d)


不带参数也是错误，证明应该是工具运行失败了，或找不到工具

```
Run cmd /c "dotnet TagToVersion"
  cmd /c "dotnet TagToVersion"
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    DOTNET_ROOT: C:\Program Files\dotnet
Error: Process completed with exit code 1.
```

在 3e4e0dd679296c8a6a86804bc1252878b937e9ec `actions/setup-dotnet@v4` 之前执行，就能执行成功
